### PR TITLE
Refactor ContentLoaders

### DIFF
--- a/src/main/java/com/ewyboy/bibliotheca/common/loaders/BlockLoader.java
+++ b/src/main/java/com/ewyboy/bibliotheca/common/loaders/BlockLoader.java
@@ -1,0 +1,36 @@
+package com.ewyboy.bibliotheca.common.loaders;
+
+import com.ewyboy.bibliotheca.common.content.item.BaseItemBlock;
+import com.ewyboy.bibliotheca.util.ModLogger;
+import net.minecraft.block.Block;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraftforge.registries.ForgeRegistries;
+
+public class BlockLoader extends ContentLoader<Block> {
+    public static final BlockLoader INSTANCE = new BlockLoader();
+
+    private BlockLoader() {
+        super(ForgeRegistries.BLOCKS);
+    }
+
+    @Override
+    protected void onRegister(String name, Block block) {
+        getRegister().register(name, () -> block);
+        getContentMap().put(block.getRegistryName(), block);
+        ModLogger.info("[BLOCK]: {} has been registered by Bibliotheca for {}", name, activeModName());
+
+        // Handle Block Items
+        BlockItem item;
+        if (block instanceof IHasCustomBlockItem) {
+            item = ((IHasCustomBlockItem) block).getCustomBlockItem();
+        } else {
+            Item.Properties properties = new Item.Properties();
+            // Add custom Item Groups
+            if (block instanceof IHasCustomGroup)
+                properties.group(((IHasCustomGroup) block).getCustomItemGroup());
+            item = new BaseItemBlock(block, properties);
+        }
+        ItemLoader.INSTANCE.onRegister(name, item);
+    }
+}

--- a/src/main/java/com/ewyboy/bibliotheca/common/loaders/ItemLoader.java
+++ b/src/main/java/com/ewyboy/bibliotheca/common/loaders/ItemLoader.java
@@ -1,0 +1,20 @@
+package com.ewyboy.bibliotheca.common.loaders;
+
+import com.ewyboy.bibliotheca.util.ModLogger;
+import net.minecraft.item.Item;
+import net.minecraftforge.registries.ForgeRegistries;
+
+public class ItemLoader extends ContentLoader<Item> {
+    public static final ItemLoader INSTANCE = new ItemLoader();
+
+    private ItemLoader() {
+        super(ForgeRegistries.ITEMS);
+    }
+
+    @Override
+    protected void onRegister(String name, Item item) {
+        getRegister().register(name, () -> item);
+        getContentMap().put(item.getRegistryName(), item);
+        ModLogger.info("[ITEM]: {} has been registered by Bibliotheca for {}", name, activeModName());
+    }
+}

--- a/src/main/java/com/ewyboy/bibliotheca/common/loaders/TileLoader.java
+++ b/src/main/java/com/ewyboy/bibliotheca/common/loaders/TileLoader.java
@@ -1,0 +1,20 @@
+package com.ewyboy.bibliotheca.common.loaders;
+
+import com.ewyboy.bibliotheca.util.ModLogger;
+import net.minecraft.tileentity.TileEntityType;
+import net.minecraftforge.registries.ForgeRegistries;
+
+public class TileLoader extends ContentLoader<TileEntityType<?>> {
+    public static final TileLoader INSTANCE = new TileLoader();
+
+    private TileLoader() {
+        super(ForgeRegistries.TILE_ENTITIES);
+    }
+
+    @Override
+    protected void onRegister(String name, TileEntityType<?> tileType) {
+        getRegister().register(name, () -> tileType);
+        getContentMap().put(tileType.getRegistryName(), tileType);
+        ModLogger.info("[TILE-TYPE]: {} has been registered by Bibliotheca for {}", name, activeModName());
+    }
+}


### PR DESCRIPTION
Move each ContentLoader into it's own subclass, and added the ContentLoader#onRegister method to make it easier to add functionality to each individual ContentLoader.

Signed-off-by: Luke Gilfoyle <boo122333@gmail.com>
