### PR TITLE
Add a way to make Tiles with Energy easier

### DIFF
--- a/src/main/java/com/ewyboy/bibliotheca/common/content/tile/BibliothecaEnergyStorage.java
+++ b/src/main/java/com/ewyboy/bibliotheca/common/content/tile/BibliothecaEnergyStorage.java
@@ -1,0 +1,47 @@
+package com.ewyboy.bibliotheca.common.content.tile;
+
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraftforge.energy.EnergyStorage;
+
+public class BibliothecaEnergyStorage extends EnergyStorage {
+    private static final String NBT_KEY_ENERGY_INFO = "energy-info";
+    private static final String NBT_KEY_CAPACITY = "capacity";
+    private static final String NBT_KEY_MAX_RECEIVE = "maxReceive";
+    private static final String NBT_KEY_MAX_EXTRACT = "maxExtract";
+    private static final String NBT_KEY_ENERGY = "energy";
+
+    public BibliothecaEnergyStorage(int capacity) {
+        super(capacity);
+    }
+
+    public BibliothecaEnergyStorage(int capacity, int maxTransfer) {
+        super(capacity, maxTransfer);
+    }
+
+    public BibliothecaEnergyStorage(int capacity, int maxReceive, int maxExtract) {
+        super(capacity, maxReceive, maxExtract);
+    }
+
+    public BibliothecaEnergyStorage(int capacity, int maxReceive, int maxExtract, int energy) {
+        super(capacity, maxReceive, maxExtract, energy);
+    }
+
+    public void save(CompoundNBT compound) {
+        CompoundNBT myInfo = new CompoundNBT();
+        myInfo.putInt(NBT_KEY_CAPACITY, capacity);
+        myInfo.putInt(NBT_KEY_MAX_RECEIVE, maxReceive);
+        myInfo.putInt(NBT_KEY_MAX_EXTRACT, maxExtract);
+        myInfo.putInt(NBT_KEY_ENERGY, energy);
+        compound.put(NBT_KEY_ENERGY_INFO, myInfo);
+    }
+
+
+    public void load(CompoundNBT compound) {
+        if (!compound.contains(NBT_KEY_ENERGY_INFO)) return;
+        CompoundNBT myInfo = compound.getCompound(NBT_KEY_ENERGY_INFO);
+        myInfo.putInt(NBT_KEY_CAPACITY, capacity);
+        myInfo.putInt(NBT_KEY_MAX_RECEIVE, maxReceive);
+        myInfo.putInt(NBT_KEY_MAX_EXTRACT, maxExtract);
+        myInfo.putInt(NBT_KEY_ENERGY, energy);
+    }
+}

--- a/src/main/java/com/ewyboy/bibliotheca/common/content/tile/ConsumerEnergyStorage.java
+++ b/src/main/java/com/ewyboy/bibliotheca/common/content/tile/ConsumerEnergyStorage.java
@@ -1,0 +1,20 @@
+package com.ewyboy.bibliotheca.common.content.tile;
+
+public class ConsumerEnergyStorage extends BibliothecaEnergyStorage {
+    public ConsumerEnergyStorage(int capacity) {
+        super(capacity);
+    }
+
+    public ConsumerEnergyStorage(int capacity, int maxReceive) {
+        super(capacity, maxReceive, 0);
+    }
+
+    public void addEnergy(int amount) {
+        energy += amount;
+    }
+
+    public void useEnergy(int amount) {
+        addEnergy(-amount);
+    }
+
+}

--- a/src/main/java/com/ewyboy/bibliotheca/common/content/tile/ExampleEnergyTile.java
+++ b/src/main/java/com/ewyboy/bibliotheca/common/content/tile/ExampleEnergyTile.java
@@ -1,0 +1,59 @@
+package com.ewyboy.bibliotheca.common.content.tile;
+
+import com.ewyboy.bibliotheca.util.LazyOptionalHelper;
+import com.google.common.collect.ImmutableSet;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.Direction;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.energy.IEnergyStorage;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class ExampleEnergyTile extends TileEntity {
+    private static final int capacity = 3000;
+    private static final int maxIn = 500;
+    private ConsumerEnergyStorage battery = new ConsumerEnergyStorage(capacity, maxIn);
+    private LazyOptional<IEnergyStorage> energyOptional = LazyOptional.of(() -> battery);
+
+    public ExampleEnergyTile() {
+        super(null); // Note: this is not how it should be in the real ones
+    }
+
+    @Override
+    public CompoundNBT write(CompoundNBT compound) {
+        battery.save(compound);
+        return super.write(compound);
+    }
+
+    @Override
+    public void read(CompoundNBT compound) {
+        battery.load(compound);
+        super.read(compound);
+    }
+
+    @Override
+    protected void invalidateCaps() {
+        super.invalidateCaps();
+        energyOptional.invalidate();
+    }
+
+    private LazyOptional<IEnergyStorage> getEnergyOptional() {
+        if (!energyOptional.isPresent()) {
+            energyOptional = LazyOptional.of(() -> battery);
+        }
+        return energyOptional;
+    }
+
+    @Nonnull
+    @Override
+    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side) {
+        return LazyOptionalHelper.findFirst(ImmutableSet.of(
+                () -> CapabilityEnergy.ENERGY.orEmpty(cap, getEnergyOptional()),
+                () -> super.getCapability(cap, side)
+        )).cast();
+    }
+}

--- a/src/main/java/com/ewyboy/bibliotheca/util/LazyOptionalHelper.java
+++ b/src/main/java/com/ewyboy/bibliotheca/util/LazyOptionalHelper.java
@@ -1,0 +1,18 @@
+package com.ewyboy.bibliotheca.util;
+
+import net.minecraftforge.common.util.LazyOptional;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class LazyOptionalHelper {
+    public static <U> LazyOptional<U> findFirst(Set<Supplier<LazyOptional<?>>> los) {
+        for (Supplier<LazyOptional<?>> sup : los) {
+            LazyOptional<?> lo = sup.get();
+            if (lo.isPresent()) {
+                return lo.cast();
+            }
+        }
+        return LazyOptional.empty();
+    }
+}


### PR DESCRIPTION
Adds ConsumerEnergyStorage which only allows for the energy to be given.
Adds BibliothecaEnergyStorage which handles energy storage nbt stuffs.

Signed-off-by: Luke Gilfoyle <boo122333@gmail.com>
