### PR TITLE
Fix the ContentLoader's content map

### DIFF
--- a/src/main/java/com/ewyboy/bibliotheca/common/loaders/BlockLoader.java
+++ b/src/main/java/com/ewyboy/bibliotheca/common/loaders/BlockLoader.java
@@ -17,8 +17,7 @@ public class BlockLoader extends ContentLoader<Block> {
 
     @Override
     protected void onRegister(String name, Block block) {
-        getRegister().register(name, () -> block);
-        getContentMap().put(block.getRegistryName(), block);
+        getContentMap().put(block.getRegistryName(), getRegister().register(name, () -> block));
         ModLogger.info("[BLOCK]: {} has been registered by Bibliotheca for {}", name, activeModName());
 
         // Handle Block Items

--- a/src/main/java/com/ewyboy/bibliotheca/common/loaders/ContentLoader.java
+++ b/src/main/java/com/ewyboy/bibliotheca/common/loaders/ContentLoader.java
@@ -15,6 +15,7 @@ import net.minecraftforge.registries.IForgeRegistryEntry;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public abstract class ContentLoader<ContentType extends IForgeRegistryEntry<ContentType>> {
 
@@ -28,9 +29,9 @@ public abstract class ContentLoader<ContentType extends IForgeRegistryEntry<Cont
 
     private final IForgeRegistry<ContentType> registry;
     private final Map<String, DeferredRegister<ContentType>> REGISTERS = Maps.newHashMap();
-    private final Map<ResourceLocation, ContentType> CONTENT_MAP = Maps.newHashMap();
+    private final Map<ResourceLocation, Supplier<ContentType>> CONTENT_MAP = Maps.newHashMap();
 
-    public Map<ResourceLocation, ContentType> getContentMap() {
+    public Map<ResourceLocation, Supplier<ContentType>> getContentMap() {
         return CONTENT_MAP;
     }
 

--- a/src/main/java/com/ewyboy/bibliotheca/common/loaders/ItemLoader.java
+++ b/src/main/java/com/ewyboy/bibliotheca/common/loaders/ItemLoader.java
@@ -14,8 +14,7 @@ public class ItemLoader extends ContentLoader<Item> {
 
     @Override
     protected void onRegister(String name, Item item) {
-        getRegister().register(name, () -> item);
-        getContentMap().put(item.getRegistryName(), item);
+        getContentMap().put(item.getRegistryName(), getRegister().register(name, () -> item));
         ModLogger.info("[ITEM]: {} has been registered by Bibliotheca for {}", name, activeModName());
     }
 }

--- a/src/main/java/com/ewyboy/bibliotheca/common/loaders/TileLoader.java
+++ b/src/main/java/com/ewyboy/bibliotheca/common/loaders/TileLoader.java
@@ -13,8 +13,7 @@ public class TileLoader extends ContentLoader<TileEntityType<?>> {
 
     @Override
     protected void onRegister(String name, TileEntityType<?> tileType) {
-        getRegister().register(name, () -> tileType);
-        getContentMap().put(tileType.getRegistryName(), tileType);
+        getContentMap().put(tileType.getRegistryName(), getRegister().register(name, () -> tileType));
         ModLogger.info("[TILE-TYPE]: {} has been registered by Bibliotheca for {}", name, activeModName());
     }
 }

--- a/src/main/java/com/ewyboy/bibliotheca/compatibilities/hwyla/WailaCompatibility.java
+++ b/src/main/java/com/ewyboy/bibliotheca/compatibilities/hwyla/WailaCompatibility.java
@@ -1,12 +1,12 @@
 package com.ewyboy.bibliotheca.compatibilities.hwyla;
 
 import com.ewyboy.bibliotheca.common.loaders.BlockLoader;
-import com.ewyboy.bibliotheca.common.loaders.ContentLoader;
 import com.ewyboy.bibliotheca.util.ModLogger;
 import mcp.mobius.waila.api.*;
 import net.minecraft.util.text.ITextComponent;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 @WailaPlugin
 public class WailaCompatibility implements IComponentProvider, IWailaPlugin {
@@ -24,7 +24,7 @@ public class WailaCompatibility implements IComponentProvider, IWailaPlugin {
     @Override
     public void register(IRegistrar registrar) {
         if (!loaded) {
-            BlockLoader.INSTANCE.getContentMap().values().forEach(block -> {
+            BlockLoader.INSTANCE.getContentMap().values().stream().map(Supplier::get).forEach(block -> {
                 if (block instanceof IWailaInfo) {
                     ModLogger.info("Waila information registered for " + block.getRegistryName());
                     registrar.registerComponentProvider(INSTANCE, TooltipPosition.BODY, block.getClass());


### PR DESCRIPTION
Convert it to use the RegistryObject, so the value gotten is always the most relevant.

Signed-off-by: Luke Gilfoyle <boo122333@gmail.com>
